### PR TITLE
fix(xhr): handle `loadend` event

### DIFF
--- a/src/interceptors/xhr.ts
+++ b/src/interceptors/xhr.ts
@@ -189,6 +189,9 @@ export const interceptXHR: Interceptor<FetchMiddleware> = function (
     set onload(callback: (this: XMLHttpRequest, ev: ProgressEvent) => any) {
       this.#listeners.push(['load', callback, false])
     }
+    set onloadend(callback: (this: XMLHttpRequest, ev: ProgressEvent) => any) {
+      this.#listeners.push(['loadend', callback, false])
+    }
     set onerror(callback: (this: XMLHttpRequest, ev: ProgressEvent) => any) {
       this.#listeners.push(['error', callback, false])
     }


### PR DESCRIPTION
The `onloadend` setter was not overridden,
so the native implementation is used which emits the event too early. With e.g. Axios this causes an incorrect event order:
- loadstart
- middleware start
- loadend
- middleware end
- load

So we need to override the `onloadend` setter like we did with `onload`, so the order now is:
- loadstart
- middleware start
- middleware end
- load
- loadend

before | after
---|---
<img width="1267" height="763" alt="Bildschirmfoto_20251204_143432" src="https://github.com/user-attachments/assets/a50df51d-0f2a-4f99-8906-4a230342bdfa" />|<img width="779" height="661" alt="Bildschirmfoto_20251204_143504" src="https://github.com/user-attachments/assets/1c8190c5-6392-42ae-a2e1-c5709d918114" />

