### PR TITLE
fix(xhr): properly pass request body to XHR in Firefox

### DIFF
--- a/src/interceptors/xhr.ts
+++ b/src/interceptors/xhr.ts
@@ -415,11 +415,7 @@ export const interceptXHR: Interceptor<FetchMiddleware> = function (
         ])
         if (c.req !== origin.req) {
           super.send.apply(this, [sendBody])
-        } else if (c.req.body) {
-          super.send.apply(this, [this.#body])
-        }
-        // body is undefined when the request in Firefox 🤡
-        else {
+        } else {
           super.send.apply(this, [this.#body])
         }
       })

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -47,6 +47,10 @@ export async function setup(project: TestProject) {
         },
       })
     })
+    .put('/echo', async (c) => {
+      const body = await c.req.text()
+      return c.text(body)
+    })
     .get('/sse', (c) => {
       const count = Number(c.req.query('count'))
       const sleep = c.req.query('sleep') ? Number(c.req.query('sleep')) : 10

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
             enabled: true,
             instances: [
               { browser: 'chromium' },
-              // { browser: 'firefox' },
+              { browser: 'firefox' },
               // { browser: 'webkit' },
             ],
             headless: true,


### PR DESCRIPTION
Firefox does not yet support XHR with ReadableStreams thus Request.body does not exist[1].
So to pass the request body to the XHR request we need to use the internal arrayBuffer of the request.
This fixes the case where you want to modify the request body within an interceptor.

[1]: https://bugzilla.mozilla.org/show_bug.cgi?id=1387483